### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/covidbot/local/covid.py
+++ b/covidbot/local/covid.py
@@ -5,7 +5,7 @@ from typing import ClassVar
 
 import numpy as np
 import requests
-from fuzzywuzzy import process
+from rapidfuzz import process
 from numpy import random
 
 from .utils import distribution

--- a/covidbot/requirements.txt
+++ b/covidbot/requirements.txt
@@ -9,7 +9,7 @@ cycler==0.10.0
 decorator==4.4.2
 defusedxml==0.6.0
 entrypoints==0.3
-fuzzywuzzy[speedup]==0.18.0
+rapidfuzz==0.2.0
 humanize==2.0.0
 idna==2.9
 importlib-metadata==1.5.0 ; python_version < '3.8'


### PR DESCRIPTION
FuzzyWuzzy and Python-Levenshtein are both GPLv2 licensed which would force you to licence the whole project under GPLv2. I had the same problem on one of my projects and so I wrote rapidfuzz which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed and is therefor MIT Licensed aswell, so it can be used in here without forcing a License change. As a nice bonus it is fully implemented in C++ and comes with a few Algorithmic improvements making it between 5 and 100 times faster than FuzzyWuzzy.