### PR TITLE
remove python-Levenshtein

### DIFF
--- a/covidbot/requirements.txt
+++ b/covidbot/requirements.txt
@@ -46,7 +46,6 @@ pygments==2.6.1
 pyparsing==2.4.6
 pyrsistent==0.15.7
 python-dateutil==2.8.1
-python-levenshtein==0.12.0
 pytz==2019.3
 pyzmq==19.0.0
 qtconsole==4.7.1


### PR DESCRIPTION
I just realised I forgot to remove python-Levenshtein from the requirements, which is not needed with rapidfuzz anymore