### PR TITLE
Hide fatality rate when it's 0%

### DIFF
--- a/covidbot/local/alerts.py
+++ b/covidbot/local/alerts.py
@@ -94,7 +94,7 @@ class Alerts(Covid, Graph, Image):
         rate = round(deaths / cases * 100, 2)
 
         self.post(
-            f"Latest COVID-19 data for {data['country']}: {humanize.intcomma(cases)} case{'s' if cases > 1 else ''}, of those {humanize.intcomma(data['todayCases'])} today; {humanize.intcomma(deaths)} death{'s' if deaths > 1 else ''}, of those {humanize.intcomma(data['todayDeaths'])} today.\n\nA {rate}% fatality rate."
+            f"Latest COVID-19 data for {data['country']}: {humanize.intcomma(cases)} case{'s' if cases > 1 else ''}, of those {humanize.intcomma(data['todayCases'])} today; {humanize.intcomma(deaths)} death{'s' if deaths > 1 else ''}, of those {humanize.intcomma(data['todayDeaths'])} today.{"\n\nA f'{rate}'% fatality rate." if rate}"
         )
 
     def __first_batch(self, data):


### PR DESCRIPTION
A 0% fatality rate probably means it's too early to call, better hide it than present a false impression of improvement.